### PR TITLE
fix: assign element's original properties not replace them

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,15 @@ module.exports = ({ markdownAST: mdast }, pluginOptions) => {
     targetNodes.forEach(node => {
       if (!node.data) node.data = {};
 
-      const props = propOfEl[el];
+      let props = propOfEl[el];
+
       if (typeof props === "string" || Array.isArray(props)) {
-        node.data.hProperties = {
+        props = {
           className: props,
         }
       }
-      else {
-        node.data.hProperties = props;
-      }
+      // if node.data.hProperties has already set, then assign it.
+      node.data.hProperties = Object.assign({}, node.data.hProperties, props)
     })
   })
 }


### PR DESCRIPTION
Hi, 

I found that this plugin will directly replace the element's properties, but I think it should check if it already exist properties.

I made a pull request for that, Can you review it?

Thanks.